### PR TITLE
feat: implement --push flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ cascade apply \
   --message "Update dependencies" \
   --base-branch main \         # Branch to apply changes to
   --pull \                     # Pull latest changes first
+  --push \                     # Push new branch to origin
   ./repo1 ./repo2
 ```
 
@@ -67,6 +68,7 @@ Optional parameters:
 
 - `--base-branch` - Branch to check out and apply changes to (default: current branch)
 - `--pull` - Pull latest changes from remote before applying changes (default: false)
+- `--push` - Push changes to remote after applying them (default: false)
 
 To see available commands:
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -18,6 +18,7 @@ var (
 	message    string
 	baseBranch string
 	pullLatest bool
+	push       bool
 
 	gitCheckoutBranch         = git.CheckoutBranch
 	gitCheckoutExistingBranch = git.CheckoutExistingBranch
@@ -25,6 +26,7 @@ var (
 	gitCommitChanges          = git.CommitChanges
 	gitExecuteScript          = git.ExecuteScript
 	gitPullLatest             = git.PullLatest
+	gitPushChanges            = git.PushChanges
 )
 
 var applyCmd = &cobra.Command{
@@ -94,6 +96,7 @@ func init() {
 	// Optional flags
 	applyCmd.Flags().StringVar(&baseBranch, "base-branch", "", "Branch to check out and apply changes to")
 	applyCmd.Flags().BoolVar(&pullLatest, "pull", false, "Pull latest changes from remote before applying changes")
+	applyCmd.Flags().BoolVar(&push, "push", false, "Push new branch to origin after applying the changes")
 }
 
 // ResetFlags resets all global flag variables to their zero values
@@ -104,6 +107,7 @@ func ResetFlags() {
 	message = ""
 	baseBranch = ""
 	pullLatest = false
+	push = false
 }
 
 func runApply(cmd *cobra.Command, args []string) error {
@@ -164,6 +168,13 @@ func runApply(cmd *cobra.Command, args []string) error {
 		if err := gitCommitChanges(repoPath, message); err != nil {
 			results.errors[repoPath] = fmt.Errorf("commit failed: %w", err)
 			continue
+		}
+
+		if push {
+			if err := gitPushChanges(repoPath, branch); err != nil {
+				results.errors[repoPath] = fmt.Errorf("push failed: %w", err)
+				continue
+			}
 		}
 
 		results.success = append(results.success, repoPath)

--- a/internal/git/operations.go
+++ b/internal/git/operations.go
@@ -72,3 +72,12 @@ func PullLatest(repoPath string) error {
 	}
 	return nil
 }
+
+func PushChanges(repoPath string, branch string) error {
+	cmd := exec.Command("git", "push", "-u", "origin", branch)
+	cmd.Dir = repoPath
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("error pushing changes: %w\n%s", err, string(output))
+	}
+	return nil
+}

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -261,6 +261,84 @@ index 0000000..9daeafb
 		}
 	})
 
+	t.Run("push changes to remote", func(t *testing.T) {
+		resetFlags()
+
+		// Create a bare remote repository
+		remoteRepo := filepath.Join(testDir, "remote-push")
+		if err := os.MkdirAll(remoteRepo, 0755); err != nil {
+			t.Fatal(err)
+		}
+		runGitCmd(t, remoteRepo, "init", "--bare")
+
+		// Clone the remote repository
+		clonedRepo := filepath.Join(testDir, "cloned-push")
+		runGitCmd(t, testDir, "clone", remoteRepo, clonedRepo)
+
+		// Set up git config in cloned repo
+		runGitCmd(t, clonedRepo, "config", "user.email", "test@example.com")
+		runGitCmd(t, clonedRepo, "config", "user.name", "Test User")
+		runGitCmd(t, clonedRepo, "config", "commit.gpgsign", "false")
+
+		// Create initial commit in cloned repo
+		readmeFile := filepath.Join(clonedRepo, "README.md")
+		if err := os.WriteFile(readmeFile, []byte("# Test Repository"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		runGitCmd(t, clonedRepo, "add", "README.md")
+		runGitCmd(t, clonedRepo, "commit", "-m", "Initial commit")
+		runGitCmd(t, clonedRepo, "push", "origin", "main")
+
+		// Create a patch file
+		patchContent := `diff --git a/pushed.txt b/pushed.txt
+new file mode 100644
+index 0000000..9daeafb
+--- /dev/null
++++ b/pushed.txt
+@@ -0,0 +1 @@
++pushed content
+`
+		patchFile := filepath.Join(testDir, "push.patch")
+		if err := os.WriteFile(patchFile, []byte(patchContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Set up command line arguments
+		os.Args = []string{
+			"cascade",
+			"apply",
+			"--patch", patchFile,
+			"--branch", "feature/push-test",
+			"--message", "Add pushed.txt",
+			"--push",
+			clonedRepo,
+		}
+
+		// Run the command
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute failed: %v", err)
+		}
+
+		// Verify changes were pushed to remote by cloning to a new directory
+		verifyRepo := filepath.Join(testDir, "verify-push")
+		runGitCmd(t, testDir, "clone", remoteRepo, verifyRepo)
+		runGitCmd(t, verifyRepo, "checkout", "feature/push-test")
+
+		// Verify file exists and has correct content
+		pushedFile := filepath.Join(verifyRepo, "pushed.txt")
+		content, err := os.ReadFile(pushedFile)
+		if err != nil {
+			t.Errorf("pushed.txt not found in remote repository")
+		} else if string(content) != "pushed content\n" {
+			t.Errorf("Expected content 'pushed content', got '%s' in remote", string(content))
+		}
+
+		// Verify commit message
+		if msg := getLastCommitMessage(t, verifyRepo); msg != "Add pushed.txt" {
+			t.Errorf("Expected commit message 'Add pushed.txt', got '%s'", msg)
+		}
+	})
+
 	t.Run("fail on invalid repository", func(t *testing.T) {
 		resetFlags()
 		invalidRepo := filepath.Join(testDir, "not-a-repo")

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -269,7 +269,7 @@ index 0000000..9daeafb
 		if err := os.MkdirAll(remoteRepo, 0755); err != nil {
 			t.Fatal(err)
 		}
-		runGitCmd(t, remoteRepo, "init", "--bare")
+		runGitCmd(t, remoteRepo, "init", "--bare", "-b", "main")
 
 		// Clone the remote repository
 		clonedRepo := filepath.Join(testDir, "cloned-push")

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -329,7 +329,7 @@ index 0000000..9daeafb
 		content, err := os.ReadFile(pushedFile)
 		if err != nil {
 			t.Errorf("pushed.txt not found in remote repository")
-		} else if string(content) != "pushed content\n" {
+		} else if strings.TrimSpace(string(content)) != "pushed content" {
 			t.Errorf("Expected content 'pushed content', got '%s' in remote", string(content))
 		}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The cascade apply command now includes a new push option (`--push`) that allows users to automatically push a newly created branch to the remote repository after applying changes.

- **Documentation**
  - Updated usage examples and command guides to clearly demonstrate the new push functionality, streamlining workflow integration for managing multiple Git repositories.

- **Tests**
  - Added new integration test cases to verify the functionality of pushing changes to a remote repository, ensuring robust testing of the new feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->