### PR TITLE
feat: make output more concise

### DIFF
--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -81,7 +81,7 @@ func TestRunApply(t *testing.T) {
 			baseBranch: "main",
 			mockSetup: func() {
 				resetMocks()
-				gitCheckoutExistingBranch = func(repoPath, branch string) error {
+				gitCheckoutExistingBranch = func(_, _ string) error {
 					return fmt.Errorf("base branch checkout failed")
 				}
 			},
@@ -95,7 +95,7 @@ func TestRunApply(t *testing.T) {
 			pullLatest: true,
 			mockSetup: func() {
 				resetMocks()
-				gitPullLatest = func(repoPath string) error {
+				gitPullLatest = func(_ string) error {
 					return fmt.Errorf("pull failed")
 				}
 			},
@@ -109,7 +109,7 @@ func TestRunApply(t *testing.T) {
 			push:      true,
 			mockSetup: func() {
 				resetMocks()
-				gitPushChanges = func(repoPath, branch string, _ bool) error {
+				gitPushChanges = func(_, _ string, _ bool) error {
 					return fmt.Errorf("push failed")
 				}
 			},
@@ -148,13 +148,29 @@ func TestRunApply(t *testing.T) {
 			wantErrors:  3,
 		},
 		{
+			name:      "some_success_some_fail_patch",
+			repos:     []string{"repo1", "repo2", "repo3"},
+			useScript: false,
+			mockSetup: func() {
+				resetMocks()
+				gitCommitChanges = func(repoPath, _ string, _ bool) error {
+					if repoPath == "repo2" {
+						return fmt.Errorf("commit error")
+					}
+					return nil
+				}
+			},
+			wantSuccess: 2,
+			wantErrors:  1,
+		},
+		{
 			name:      "mixed_results_script",
 			repos:     []string{"repo1", "repo2", "repo3"},
 			useScript: true,
 			mockSetup: func() {
 				resetMocks()
 				// Fail checkout for repo1
-				gitCheckoutBranch = func(repoPath, branch string) error {
+				gitCheckoutBranch = func(repoPath, _ string) error {
 					if repoPath == "repo1" {
 						return fmt.Errorf("checkout error")
 					}

--- a/internal/log/apply.go
+++ b/internal/log/apply.go
@@ -1,0 +1,84 @@
+package log
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"sync"
+)
+
+// ApplyLogger writes detailed apply errors to a file for later inspection.
+type ApplyLogger struct {
+	mu     sync.Mutex
+	file   *os.File
+	logger *log.Logger
+}
+
+// NewApplyLogger creates a log file in the OS temp directory.
+func NewApplyLogger() (*ApplyLogger, error) {
+	file, err := os.CreateTemp("", "cascade-apply-*.log")
+	if err != nil {
+		return nil, fmt.Errorf("create apply log file: %w", err)
+	}
+
+	return &ApplyLogger{
+		file:   file,
+		logger: log.New(file, "", log.LstdFlags),
+	}, nil
+}
+
+// Path returns the log file path.
+func (l *ApplyLogger) Path() string {
+	return l.file.Name()
+}
+
+// Close closes the underlying log file.
+func (l *ApplyLogger) Close() error {
+	return l.file.Close()
+}
+
+// LogRepoError records the full error chain for a repository.
+func (l *ApplyLogger) LogRepoError(repo string, err error) {
+	if err == nil {
+		return
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.logger.Printf("repo: %s", repo)
+	for _, line := range formatErrorChain(err) {
+		l.logger.Print(line)
+	}
+	l.logger.Print("")
+}
+
+func formatErrorChain(err error) []string {
+	var lines []string
+	var visit func(err error, depth int)
+
+	visit = func(err error, depth int) {
+		if err == nil {
+			return
+		}
+
+		indent := strings.Repeat("  ", depth)
+		lines = append(lines, fmt.Sprintf("%s- %s", indent, err.Error()))
+
+		if unwrapped, ok := err.(interface{ Unwrap() []error }); ok {
+			for _, nested := range unwrapped.Unwrap() {
+				visit(nested, depth+1)
+			}
+			return
+		}
+
+		if next := errors.Unwrap(err); next != nil {
+			visit(next, depth+1)
+		}
+	}
+
+	visit(err, 0)
+	return lines
+}

--- a/internal/log/apply_test.go
+++ b/internal/log/apply_test.go
@@ -1,0 +1,67 @@
+package log
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestNewApplyLogger(t *testing.T) {
+	logger, err := NewApplyLogger()
+	if err != nil {
+		t.Fatalf("NewApplyLogger() error: %v", err)
+	}
+
+	path := logger.Path()
+	if path == "" {
+		t.Fatal("Path() returned empty string")
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat log file: %v", err)
+	}
+	if info.IsDir() {
+		t.Fatalf("expected log file, got directory: %s", path)
+	}
+
+	if err := logger.Close(); err != nil {
+		t.Fatalf("Close() error: %v", err)
+	}
+	_ = os.Remove(path)
+}
+
+func TestApplyLoggerLogRepoError(t *testing.T) {
+	logger, err := NewApplyLogger()
+	if err != nil {
+		t.Fatalf("NewApplyLogger() error: %v", err)
+	}
+
+	path := logger.Path()
+	repoErr := fmt.Errorf("outer: %w", errors.New("inner"))
+	logger.LogRepoError("repo1", repoErr)
+
+	if err := logger.Close(); err != nil {
+		t.Fatalf("Close() error: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	text := string(data)
+
+	for _, want := range []string{
+		"repo: repo1",
+		"- outer: inner",
+		"  - inner",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected log output to contain %q, got:\n%s", want, text)
+		}
+	}
+
+	_ = os.Remove(path)
+}


### PR DESCRIPTION
The old way of printing repo names along with the errors was very verbose, consumed the whole scrollback buffer and didn't let the user see the results at a glance.

We make the output more concise by just printing the ok/fail results in the console and storing the detailed error logs in a separate log file.