### PR TITLE
feat: add --open-remote-url flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Optional parameters:
 - `--push` - Push changes to remote after applying them (default: false)
 - `--no-verify` - Skip git commit and push hooks (default: false)
 - `--stash` - Stash tracked and untracked changes before applying changes (default: false)
+- `--open-remote-url` - Open the last URL from git push output in the default browser, often links to the PR/MR creation page with default Github and Gitlab server configurations (requires `--push`, default: false)
 
 To see available commands:
 

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -16,7 +16,7 @@ func resetMocks() {
 	gitCommitChanges = func(repoPath, message string, noVerify bool) error { return nil }
 	gitExecuteScript = func(repoPath, scriptPath string) error { return nil }
 	gitPullLatest = func(repoPath string) error { return nil }
-	gitPushChanges = func(repoPath, branch string, noVerify bool) error { return nil }
+	gitPushChanges = func(repoPath, branch string, noVerify bool) (string, error) { return "", nil }
 	gitStashChanges = func(repoPath string) error { return nil }
 }
 
@@ -134,8 +134,8 @@ func TestRunApply(t *testing.T) {
 			push:      true,
 			mockSetup: func() {
 				resetMocks()
-				gitPushChanges = func(_, _ string, _ bool) error {
-					return fmt.Errorf("push failed")
+				gitPushChanges = func(_, _ string, _ bool) (string, error) {
+					return "", fmt.Errorf("push failed")
 				}
 			},
 			wantSuccess: 0,
@@ -276,6 +276,7 @@ func TestRunApply(t *testing.T) {
 			push = false
 			noVerify = false
 			stash = false
+			openRemoteURL = false
 
 			// Verify results
 			if err != nil {

--- a/internal/git/operations.go
+++ b/internal/git/operations.go
@@ -98,7 +98,7 @@ func PullLatest(repoPath string) error {
 	return nil
 }
 
-func PushChanges(repoPath string, branch string, noVerify bool) error {
+func PushChanges(repoPath string, branch string, noVerify bool) (string, error) {
 	pushArgs := []string{"push"}
 	if noVerify {
 		pushArgs = append(pushArgs, "--no-verify")
@@ -106,8 +106,9 @@ func PushChanges(repoPath string, branch string, noVerify bool) error {
 	pushArgs = append(pushArgs, "-u", "origin", branch)
 	cmd := exec.Command("git", pushArgs...)
 	cmd.Dir = repoPath
-	if output, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("error pushing changes: %w\n%s", err, string(output))
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), fmt.Errorf("error pushing changes: %w\n%s", err, string(output))
 	}
-	return nil
+	return string(output), nil
 }

--- a/internal/git/remote_output.go
+++ b/internal/git/remote_output.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"regexp"
 	"runtime"
+	"strings"
 )
 
 var remoteURLPattern = regexp.MustCompile(`https?://\S+`)
@@ -32,9 +33,17 @@ func OpenLastRemoteURL(output string) error {
 }
 
 func lastRemoteURL(output string) string {
-	matches := remoteURLPattern.FindAllString(output, -1)
-	if len(matches) == 0 {
-		return ""
+	var lastMatch string
+	for line := range strings.SplitSeq(output, "\n") {
+		trimmed := strings.TrimLeft(line, " \t")
+		if !strings.HasPrefix(trimmed, "remote:") {
+			continue
+		}
+		matches := remoteURLPattern.FindAllString(trimmed, -1)
+		if len(matches) == 0 {
+			continue
+		}
+		lastMatch = matches[len(matches)-1]
 	}
-	return matches[len(matches)-1]
+	return lastMatch
 }

--- a/internal/git/remote_output.go
+++ b/internal/git/remote_output.go
@@ -1,0 +1,40 @@
+package git
+
+import (
+	"fmt"
+	"os/exec"
+	"regexp"
+	"runtime"
+)
+
+var remoteURLPattern = regexp.MustCompile(`https?://\S+`)
+
+// OpenLastRemoteURL opens the last URL from git output in the default browser.
+func OpenLastRemoteURL(output string) error {
+	url := lastRemoteURL(output)
+	if url == "" {
+		return nil
+	}
+
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("open browser failed: %w\n%s", err, string(output))
+	}
+	return nil
+}
+
+func lastRemoteURL(output string) string {
+	matches := remoteURLPattern.FindAllString(output, -1)
+	if len(matches) == 0 {
+		return ""
+	}
+	return matches[len(matches)-1]
+}

--- a/internal/git/remote_output_test.go
+++ b/internal/git/remote_output_test.go
@@ -1,0 +1,36 @@
+package git
+
+import "testing"
+
+func TestLastRemoteURL(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   string
+	}{
+		{
+			name:   "empty_output",
+			output: "",
+			want:   "",
+		},
+		{
+			name:   "single_url",
+			output: "remote: Create pull request: https://example.com/org/repo/compare/branch?expand=1",
+			want:   "https://example.com/org/repo/compare/branch?expand=1",
+		},
+		{
+			name: "multiple_urls",
+			output: "remote: View changes https://example.com/first\n" +
+				"remote: Create pull request https://example.com/second",
+			want: "https://example.com/second",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := lastRemoteURL(tt.output); got != tt.want {
+				t.Fatalf("LastRemoteURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/git/remote_output_test.go
+++ b/internal/git/remote_output_test.go
@@ -14,14 +14,21 @@ func TestLastRemoteURL(t *testing.T) {
 			want:   "",
 		},
 		{
-			name:   "single_url",
+			name:   "single_remote_url",
 			output: "remote: Create pull request: https://example.com/org/repo/compare/branch?expand=1",
 			want:   "https://example.com/org/repo/compare/branch?expand=1",
 		},
 		{
-			name: "multiple_urls",
+			name: "non_remote_ignored",
+			output: "Create PR https://example.com/ignored\n" +
+				"hint: another https://example.com/also-ignored",
+			want: "",
+		},
+		{
+			name: "multiple_remote_urls",
 			output: "remote: View changes https://example.com/first\n" +
-				"remote: Create pull request https://example.com/second",
+				"remote: Create pull request https://example.com/second\n" +
+				"hint: https://example.com/ignored",
 			want: "https://example.com/second",
 		},
 	}


### PR DESCRIPTION
Adds `--open-remote-url` flag to open the last URL printed by the remote in `git push` output. This URL with default Github and Gitlab server configurations often links to a page that lets the user immediately create a new PR/MR with a branch that was just pushed, which would speed up the creation of PRs for changes automatically applied to the repo by cascade