### PR TITLE
feat!: remove explicit windows support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
         go-version: [1.25]
     steps:
       - name: Set up Go

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,6 @@ builds:
     goos:
       - linux
       - darwin
-      - windows
     goarch:
       - amd64
       - arm64
@@ -27,8 +26,6 @@ archives:
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
     format_overrides:
-      - goos: windows
-        format: zip
       - goos: darwin
         format: zip
     files:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ Alternatively, you can download the binary from the [Releases page](https://gith
 2. Extract the archive:
    - On macOS: Double-click the .zip file or use `unzip cascade_*_Darwin_*.zip`
    - On Linux: `tar -xzf cascade_*_Linux_*.tar.gz`
-   - On Windows: Extract the .zip file using File Explorer or a tool like 7-Zip
 3. Move the `cascade` binary to a directory in your system's `PATH`.
 
 ## Usage

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"path/filepath"
-	"runtime"
 
 	"github.com/vpukhanov/cascade/internal/git"
 	applog "github.com/vpukhanov/cascade/internal/log"
@@ -47,9 +46,6 @@ var applyCmd = &cobra.Command{
 		}
 		if patchFile != "" && scriptFile != "" {
 			return fmt.Errorf("--patch and --script cannot be used together")
-		}
-		if runtime.GOOS == "windows" && scriptFile != "" {
-			return fmt.Errorf("--script option is not supported on Windows")
 		}
 		if branch == "" {
 			return fmt.Errorf("--branch is required")

--- a/internal/git/operations_test.go
+++ b/internal/git/operations_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 )
@@ -85,10 +84,6 @@ func TestCommitChanges(t *testing.T) {
 }
 
 func TestCommitChangesNoVerifySkipsHook(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("git hook shell scripts are not supported on Windows in this test")
-	}
-
 	repoPath := createTestRepo(t)
 	commitMessage := "Skip hooks\n"
 

--- a/internal/git/remote_output.go
+++ b/internal/git/remote_output.go
@@ -18,12 +18,9 @@ func OpenLastRemoteURL(output string) error {
 	}
 
 	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "darwin":
+	if runtime.GOOS == "darwin" {
 		cmd = exec.Command("open", url)
-	case "windows":
-		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
-	default:
+	} else {
 		cmd = exec.Command("xdg-open", url)
 	}
 	if output, err := cmd.CombinedOutput(); err != nil {

--- a/internal/validation/params_test.go
+++ b/internal/validation/params_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"testing"
 )
 
@@ -42,10 +41,6 @@ func TestValidateFile(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if runtime.GOOS == "windows" && tt.fileType == "script" {
-				t.Skip("Script execution is not supported on Windows [https://github.com/vpukhanov/cascade/issues/1]")
-			}
-
 			err := ValidateFile(tt.path, tt.fileType)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ValidateFile() error = %v, wantErr %v", err, tt.wantErr)

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -83,10 +83,6 @@ index 0000000..9daeafb
 	})
 
 	t.Run("apply script to multiple repositories", func(t *testing.T) {
-		if runtime.GOOS == "windows" {
-			t.Skip("Script execution is not supported on Windows [https://github.com/vpukhanov/cascade/issues/1]")
-		}
-
 		resetFlags()
 		// Create a test script
 		scriptContent := `#!/bin/sh
@@ -340,10 +336,6 @@ index 0000000..9daeafb
 	})
 
 	t.Run("open remote URL after push", func(t *testing.T) {
-		if runtime.GOOS == "windows" {
-			t.Skip("Git hook shell scripts are not supported on Windows in this test")
-		}
-
 		resetFlags()
 
 		openCmd := "xdg-open"
@@ -445,10 +437,6 @@ index 0000000..9daeafb
 	})
 
 	t.Run("push with no-verify skips pre-push hook", func(t *testing.T) {
-		if runtime.GOOS == "windows" {
-			t.Skip("Git hook shell scripts are not supported on Windows in this test")
-		}
-
 		resetFlags()
 
 		// Create a bare remote repository
@@ -562,10 +550,6 @@ index 0000000..9daeafb
 	})
 
 	t.Run("fail on non-executable script", func(t *testing.T) {
-		if runtime.GOOS == "windows" {
-			t.Skip("Script execution is not supported on Windows [https://github.com/vpukhanov/cascade/issues/1]")
-		}
-
 		resetFlags()
 		nonExecutableScript := filepath.Join(testDir, "non-executable.sh")
 		if err := os.WriteFile(nonExecutableScript, []byte("#!/bin/sh\necho test"), 0644); err != nil {


### PR DESCRIPTION
Sidestepping Windows non-support is starting to be annoying, so I'm removing partial support in favor of making maintenance easier. I assume most Windows developers use WSL anyway, and the Linux build will work fine for them.